### PR TITLE
Add a fedora-based Dockerfile with README + minor changes to requirements.txt

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,14 @@
+FROM fedora:33
+
+RUN dnf install -y pip libolm-devel gcc python-devel python3-dbus
+
+WORKDIR /app
+ 
+COPY requirements.txt .
+COPY matrix-commander.py .
+
+RUN pip3 install -r /app/requirements.txt
+
+VOLUME /data
+
+ENTRYPOINT ["/bin/python3", "/app/matrix-commander.py" ,"-s", "/data/store", "-c", "/data/credentials.json"]

--- a/docker/README.adoc
+++ b/docker/README.adoc
@@ -1,0 +1,44 @@
+= Matrix commander with Docker
+
+NOTE: In the following docker commands, the option `:z` is here to make sure that the commands work in systems that use SELinux (eg. Fedora).
+For other systems, this options has no influence and can be ignored or removed.
+
+== Building the image
+
+From the root folder of the git repository, run:
+
+```
+docker build -t matrix-commander . -f docker/Dockerfile
+```
+
+This will create an image called `matrix-commander`.
+
+
+== Using the image
+
+This image requires a folder where `matrix-commander` will store data for credentials and end-to-end encryption.
+This folder must be provided to further `run` commands using the `/data` mountpoint.
+
+=== Initialization (only do this once)
+
+Run this command to initialize the `matrix-commander` data folder with new credentials − you must answer all the questions that will pop up interactively (homeserver, username, etc.):
+```
+docker run --rm -ti -v /my/chosen/folder:/data:z matrix-commander
+```
+
+You can now use this data folder to send messages or verify your session.
+
+
+=== Send a message to a room
+
+Given an initialized data folder, run this command to send a message to a room:
+```
+docker run --rm -v /my/chosen/folder:/data:z matrix-commander -r "<room id>" -m "<some message>"
+```
+
+=== Verify the session 
+
+Given an initialized data folder, run this command to start the verification of the matrix-commander session from another existing matrix session:
+```
+docker run --rm -ti -v /my/chosen/folder:/data:z matrix-commander --verify
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
 aiohttp
-aiofiles
+aiofiles<0.5.0,>=0.4.0
 argparse
 asyncio
 datetime
-logging
 markdown
 matrix-nio[e2e]>=0.14.1
 notify2


### PR DESCRIPTION
If you're interested, I have written a first working Dockerfile for matrix-commander. I've also provided a README explaining how to build and use the image.

Unfortunately, the obtained image is rather big because it is built atop Fedora. I tried using alpine as a base, but I failed because matrix-commander required dbus and I could not find how to make the build work.

I also had to make small changes to the requirements.txt file to make it work.