### PR TITLE
Error if PID Folder creation fails

### DIFF
--- a/matrix-commander.py
+++ b/matrix-commander.py
@@ -1106,7 +1106,7 @@ def create_pid_file() -> None:
     except Exception:
         logger.debug(
             f'Failed to create PID file "{PID_FILE_DEFAULT}" '
-            f"to store process id {pid}."
+            f"to store process id {os.getpid()}."
         )
 
 


### PR DESCRIPTION
if os.mkdir in line 1095 fails pid will not be set and we will have a unbound variable in the exception logger message