### PR TITLE
Completion

### DIFF
--- a/auto-completion/bash/matrix-commander.bash
+++ b/auto-completion/bash/matrix-commander.bash
@@ -95,6 +95,8 @@ _matrix-commander ()
         -j|--config)
             COMPREPLY=( $(compgen -f -- "$cur") )
             ;;
+        -v|--verify)
+            keys=(emoji)
             COMPREPLY=( $(compgen -W "${keys[*]}" -- "$cur") )
             ;;
         *)

--- a/auto-completion/bash/matrix-commander.bash
+++ b/auto-completion/bash/matrix-commander.bash
@@ -1,0 +1,100 @@
+_matrix-commander-get-last-option ()
+{
+    local lastopt i
+
+    for (( i = ${#COMP_WORDS[@]} - 1; i >= 0; i-- )); do
+        if [[ "${COMP_WORDS[i]}" = -* ]]; then
+            lastopt="${COMP_WORDS[i]}"
+        fi
+    done
+
+    echo $lastopt
+}
+
+_matrix-commander ()
+{
+    COMPREPLY=()
+    local IFS=$'\n'
+    local -a opts
+    cur=${COMP_WORDS[COMP_CWORD]}
+
+    # prev is generally not useful since nargs=+
+    prev=${COMP_WORDS[COMP_CWORD-1]}
+    opts=(
+        -h --help
+        -d --debug
+        --log-level
+        -c --credentials
+        -r --room
+        --room-create
+        --room-join
+        --room-leave
+        --room-forget
+        --room-invite
+        --room-ban
+        --room-unban
+        --room-kick
+        --user
+        --name
+        --topic
+        -m --message
+        -i --image
+        -a --audio
+        -f --file
+        -w --html
+        -z --markdown
+        -k --code
+        -p --split
+        -j --config
+        --proxy
+        -n --notice
+        -e --encrypted
+        -s --store
+        -l --listen
+        -t --tail
+        -y --listen-self
+        --print-event-id
+        -u --download-media
+        -o --os-notify
+        -v --verify
+        -x --rename-device
+        --version
+    )
+    # option
+    if [[ "$cur" = -* ]]; then
+        COMPREPLY=( $(compgen -W "${opts[*]}" -- "$cur") )
+        return 0
+    fi
+
+    # argument to option
+    opt=$(_matrix-commander-get-last-option)
+
+    printf '%s\n' "${COMP_WORDS[@]}" > $HOME/bruh
+    printf "opt is $opt" >> $HOME/bruh
+
+    case "$opt" in
+        --log-level)
+            local keys=(DEBUG INFO WARNING ERROR CRITICAL)
+            COMPREPLY=( $(compgen -W "${keys[*]}" -- "$cur") )
+            ;;
+        -c|--credentials)
+            COMPREPLY=( $(compgen -f -- "$cur") )
+            ;;
+        -i|--image|-a|--audio|-f|--file)
+            # just allow all files since it is hard to distinguish
+            COMPREPLY=( $(compgen -f -- "$cur") )
+            ;;
+        -s|--store)
+            COMPREPLY=( $(compgen -d -- "$cur") )
+            ;;
+        -l|--listen)
+            local keys=(never once forever tail all)
+            COMPREPLY=( $(compgen -W "${keys[*]}" -- "$cur") )
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+complete -F _matrix-commander matrix-commander.py

--- a/auto-completion/bash/matrix-commander.bash
+++ b/auto-completion/bash/matrix-commander.bash
@@ -16,7 +16,7 @@ _matrix-commander ()
 {
     COMPREPLY=()
     local IFS=$'\n'
-    local -a opts
+    local -a opts keys
     cur=${COMP_WORDS[COMP_CWORD]}
 
     # prev is generally not useful since nargs=+
@@ -75,7 +75,7 @@ _matrix-commander ()
 
     case "$opt" in
         --log-level)
-            local keys=(DEBUG INFO WARNING ERROR CRITICAL)
+            keys=(DEBUG INFO WARNING ERROR CRITICAL)
             COMPREPLY=( $(compgen -W "${keys[*]}" -- "$cur") )
             ;;
         -c|--credentials)
@@ -89,7 +89,7 @@ _matrix-commander ()
             COMPREPLY=( $(compgen -d -- "$cur") )
             ;;
         -l|--listen)
-            local keys=(never once forever tail all)
+            keys=(never once forever tail all)
             COMPREPLY=( $(compgen -W "${keys[*]}" -- "$cur") )
             ;;
         -j|--config)

--- a/auto-completion/bash/matrix-commander.bash
+++ b/auto-completion/bash/matrix-commander.bash
@@ -92,6 +92,11 @@ _matrix-commander ()
             local keys=(never once forever tail all)
             COMPREPLY=( $(compgen -W "${keys[*]}" -- "$cur") )
             ;;
+        -j|--config)
+            COMPREPLY=( $(compgen -f -- "$cur") )
+            ;;
+            COMPREPLY=( $(compgen -W "${keys[*]}" -- "$cur") )
+            ;;
         *)
             return 1
             ;;

--- a/auto-completion/bash/matrix-commander.bash
+++ b/auto-completion/bash/matrix-commander.bash
@@ -70,9 +70,6 @@ _matrix-commander ()
     # argument to option
     opt=$(_matrix-commander-get-last-option)
 
-    printf '%s\n' "${COMP_WORDS[@]}" > $HOME/bruh
-    printf "opt is $opt" >> $HOME/bruh
-
     case "$opt" in
         --log-level)
             keys=(DEBUG INFO WARNING ERROR CRITICAL)

--- a/auto-completion/bash/matrix-commander.bash
+++ b/auto-completion/bash/matrix-commander.bash
@@ -5,6 +5,7 @@ _matrix-commander-get-last-option ()
     for (( i = ${#COMP_WORDS[@]} - 1; i >= 0; i-- )); do
         if [[ "${COMP_WORDS[i]}" = -* ]]; then
             lastopt="${COMP_WORDS[i]}"
+            break
         fi
     done
 


### PR DESCRIPTION
Closes #21 

- [x] bash
- [ ] zsh
- [ ] fish

I will try working on the fish and zsh but I am less familiar with their completion systems. It is possible to make zsh use bash completions so if fish shell isn't a high priority for you then maybe this can just be merged. Note that the completion is "hacky" since I loop over the arguments in `_matrix-commander-get-last-option` to find the last option (i.e., a word that starts with "-") and this strategy may be less effective on other completion systems. 