### PR TITLE
correct exit status

### DIFF
--- a/matrix-commander.py
+++ b/matrix-commander.py
@@ -4060,6 +4060,6 @@ if __name__ == "__main__":  # noqa: C901 # ignore mccabe if-too-complex
     except KeyboardInterrupt:
         logger.debug("Keyboard interrupt received.")
     cleanup()
-    sys.exit(1)
+    sys.exit(0)
 
 # EOF


### PR DESCRIPTION
If everything goes well, e.g. the message is sent the exit status should reflect success i.e. 0 not 1