### PR TITLE
prefix additional lines in multiline messages with space

### DIFF
--- a/matrix-commander.py
+++ b/matrix-commander.py
@@ -1046,12 +1046,15 @@ class Callbacks(object):
                 event_id_detail = f" | {event.event_id}"
             else:
                 event_id_detail = ""
+            # Prevent faking messages by prefixing each line of a multiline
+            # message with space.
+            fixed_msg = re.sub('\n', '\n    ', msg)
             complete_msg = (
                 "Message received for room "
                 f"{room_nick} [{room.room_id}] | "
                 f"sender {sender_nick} "
                 f"[{event.sender}] | {event_datetime}"
-                f"{event_id_detail} | {msg}"
+                f"{event_id_detail} | {fixed_msg}"
             )
             logger.debug(complete_msg)
             print(complete_msg, flush=True)


### PR DESCRIPTION
Previously, it was possible to craft multiline messages that were
indistinguishable from multiple messages being sent, with fake
room/username information.  Now, any message that spans multiple lines
will have the lines after the first prefixed by four spaces, making it
unambiguously clear that the text is part of a user message.