### PR TITLE
Add Docker image publishing Github Action

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,38 @@
+name: Publish Docker image
+
+env:
+  DOCKERHUB_IMAGE: matrix-commander
+
+on: push
+
+jobs:
+  buildx:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+        # Required if building multi-arch images
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - id: buildx
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          buildkitd-flags: --debug
+          install: true
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          file: docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_IMAGE }}:latest

--- a/docker/README.adoc
+++ b/docker/README.adoc
@@ -10,11 +10,15 @@ The provided `Dockerfile` is for Fedora, specifically Fedora 35. If you want to 
 From the root folder of the git repository, run:
 
 ```
-docker build -t matrix-commander . -f docker/Dockerfile
+docker build -t matrix-commander -f docker/Dockerfile .
 ```
 
 This will create an image called `matrix-commander`.
 
+Alternatively, you can build the Docker image directly from sources, without cloning the repo:
+```
+docker build -t matrix-commander -f docker/Dockerfile github.com/8go/matrix-commander
+```
 
 == Using the image
 


### PR DESCRIPTION
Addresses #70. Archs: amd64, arm64. I've seen i386 arch mentioned elsewhere, but Fedora does not have 32bit images.
Check the Action output on my repo: https://github.com/pataquets/matrix-commander/runs/6717715840
Pushed Docker image on Docker Hub: https://hub.docker.com/r/pataquets/matrix-commander
Needs Docker Hub's username and token secrets set on the repo's secrets settings page. Generate the DH token on DH's security settings page.

Test the image by doing
```
$ docker run --rm -it pataquets/matrix-commander --help
```

I have several Dockerfile build improvements, to be sent later. Now just focusing on this.