### PR TITLE
Dockerfile optimizations: size, speed, readability.

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,7 +33,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push 2
+      - name: Build and push
         uses: docker/build-push-action@v2
         with:
           file: docker/Dockerfile

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,18 +2,31 @@ FROM fedora:35
 
 # standard install packages: pip libolm-devel gcc python-devel python3-dbus
 # additional packages: libffi-devel libjpeg-devel zlib-devel (required on Raspberry Pi (4b, 32bit, running buster of Raspberry Pi OS))
-RUN dnf install -y pip libolm-devel gcc python-devel python3-dbus libffi-devel libjpeg-devel zlib-devel
+RUN \
+  dnf install -y --nodocs \
+    gcc \
+    libolm-devel \
+    libffi-devel \
+    libjpeg-devel \
+    pip \
+    python-devel \
+    python3-dbus \
+    zlib-devel \
+  && dnf clean all \
+  && rm -rf /var/cache/yum/
 
+RUN pip3 install --no-cache wheel
 
-WORKDIR /app
+RUN mkdir -vp /app/matrix_commander/
 
+WORKDIR /app/
 COPY requirements.txt .
-RUN mkdir -p matrix_commander
-COPY matrix_commander/matrix_commander.py matrix_commander/matrix_commander.py
-COPY matrix_commander/matrix-commander matrix_commander/matrix-commander
-COPY matrix_commander/__init__.py matrix_commander/__init__.py
+RUN pip3 install --no-cache -r requirements.txt
 
-RUN pip3 install wheel && pip3 install -r /app/requirements.txt
+WORKDIR /app/matrix_commander/
+COPY matrix_commander/matrix_commander.py .
+COPY matrix_commander/matrix-commander .
+COPY matrix_commander/__init__.py .
 
 VOLUME /data
 


### PR DESCRIPTION
Applying Docker build best practices:
* Size: skipping/cleaning up caches on each step (layer). Size reduction is around 300mb.
* Speed: (on repeated builds on local) Reorder steps to take the most advantage of Docker build layer caching. Optimizes Dockerfile for local development/hacking scenario (ie. hack->build->run->repeat),
* Readability: line breaks, indentation, block separation, verbosity.

See https://docs.docker.com/develop/develop-images/dockerfile_best-practices/ for more info and details.

Submitting early for review, since I'm still testing, but I'm not that deep on Python nor matrix-commander, so advice is needed in case something might break.