### PR TITLE
Publish images for all release tags to Docker Hub

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,13 +11,11 @@ env:
 #       - master
 
 # Adding "git push origin <tag>" made it trigger the workflow twice.
-# Hence made it so that only pushing tags triggers the workflow.
-# And only if the tag is a version ending in ".0". 
-# Minor versions like "v2.40.1" will be skipped.
+# So, only pushing schema tags with 'v' prefix triggers workflow.
 on:
   push:
     tags:
-      - 'v*.0'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   buildx:


### PR DESCRIPTION
The v3.0.0 release was published to Docker Hub but the v3.0.1 release (which adds `--logout me`) was not.

- https://github.com/8go/matrix-commander/tags
- https://hub.docker.com/r/matrixcommander/matrix-commander/tags

As it is, only releases terminating in a 0 (v3.0.0, v3.1.0 etc) will get published. This PR should ensure that all released tags are published to Docker Hub. Comparing the tag listings on Github and Docker above, we can see that releases such as v3.0.1, v2.38.1, v2.37.7 were not made available on Docker hub.

This change will publish release tags matching `v[0-9]+.[0-9]+.[0-9]+` which I believe matches this project's expected release methodology (where features and bugfixes may arrive in patch release numbers such as 3.0.1).