### PR TITLE
clarify --verify help text

### DIFF
--- a/matrix_commander/matrix_commander.py
+++ b/matrix_commander/matrix_commander.py
@@ -5611,7 +5611,7 @@ async def action_verify() -> None:
             f"{PROG_WITHOUT_EXT} is ready and waiting for the other party to "
             "initiate an emoji verification with us by selecting "
             "'Verify by Emoji' "
-            "in their Matrix client. Read --verify instructions in --help "
+            "in their Matrix client. Read --verify instructions in --manual "
             "carefully to assist you in how to do this quickly.",
             file=sys.stdout,
             flush=True,


### PR DESCRIPTION
Refer the user to --manual instead of --help, since that's where the detailed instructions for --verify can be found.

I first thought I had the same issue as https://github.com/8go/matrix-commander/issues/93 until I discovered that verification will only work if the non-matrix-commander client explicitly requests an *emoji* verification. The "regular" button in element (under "Settings/Security/Where you're signed in") only says "verify" and doesn't work, one *needs* to go via a room list to find this button. I guess this also means I can't verify matrix-commander from for instance nheko, which doesn't have an explicit button for emoji verification (I think).

I only discovered the extra help text by checking the verify code in matrix-commander, so I hope changing this to from --help to --manual will point people in the right direction at least.