### PR TITLE
readme: add few backticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,10 +253,10 @@ On creation the credentials file will by default be created in the local
 directory, so the users sees it right away. This is fine if you have
 only one or a few credential files, but for better maintainability
 it is suggested to place your credentials files into directory
-$HOME/.config/matrix-commander/. When the program looks for
+`$HOME/.config/matrix-commander/`. When the program looks for
 a credentials file it will first look in local directory and then
 as secondary choice it will look in directory
-$HOME/.config/matrix-commander/.
+`$HOME/.config/matrix-commander/`.
 
 If you want to re-use an existing device id and an existing
 access token, you can do so as well, just manually edit the
@@ -268,7 +268,7 @@ Wherever possible end-to-end encryption will be used. For e2ee to work
 efficiently a `store` directory is needed to store e2ee data persistently.
 The default location for the store directory is a local directory named
 `store`. Alternatively, as a secondary choice the program looks for a store
-directory in $HOME/.local/share/matrix-commander/store/. The user can always
+directory in `$HOME/.local/share/matrix-commander/store/`. The user can always
 specify a different location via the --store argument. The `store`
 directory will usually be created on the first run.
 
@@ -315,10 +315,10 @@ For sending messages the program supports various text formats:
 6) split: splits messages into multiple units at given pattern
 
 Photos and images that can be sent. That includes files like
-.jpg, .gif, .png or .svg.
+`.jpg`, `.gif`, `.png` or `.svg`.
 
-Arbitrary files like .txt, .pdf, .doc, audio files like .mp3
-or video files like .mp4 can also be sent.
+Arbitrary files like `.txt`, `.pdf`, `.doc`, audio files like `.mp3`
+or video files like `.mp4` can also be sent.
 
 Matrix events like sending an emoji reaction, replying as a thread,
 message edits can be sent.


### PR DESCRIPTION
# README: add a few backticks

I had backtick to:
* path beginning by a dollar
  ```diff
  - The $PATH/of
  + The `$PATH/of`
  ```
* extension name
  ```diff
  - The .pdf
  + The `.pdf`
  ```

## How

![perl-begin.org](https://perl-begin.org/images/palms-110-pixels-high-strip.jpg)

I create a `perl` script

```perl
#!/usr/bin/perl
use strict;
use warnings;

my @extensions = ("jpg", "gif", "mp4", "svg", "png", "txt", "pdf", "doc", "mp3");

my $readme = "README.md";
my $readmeUpdate = "README.md.new";
my $scopeCode = 0;

open(my $in, "<", $readme) || die "Can't open $readme $!";
open(my $out, ">", $readmeUpdate) || die "Can't open $readmeUpdate $!";

while (<$in>)
{
  # check if we are in a code scope
  if (/```/)
  {
    if ($scopeCode == 0)
    {
      $scopeCode = 1;
    }
    else
    {
      $scopeCode = 0;
    }
  }

  if ($scopeCode == 0)
  {
    # add backtick to each path beginning by a dollar
    if (/\$\w+/)
    {
      s/( |^)(\$[^\s]+)(\.( |$))/$1`$2`$3/g
    }
    
    # add backtick to each extensions types
    foreach my $extension (@extensions)
    {
      s/( |^)(\.$extension)/$1`$2`/g
    }
    
    # add backtick to each command flag
    # WIP
    # TODO
    # ignore if the flag is already between backtick
    # s/( |^|\()(\-+(\w|-)+)/$1`$2`/g
  }

  print $out $_;
}

system("mv", $readmeUpdate, $readme);

close $in;
close $out;
```