### PR TITLE
Make `matrix-commander --get-devices` work despite *last seen date* being `None`

### DIFF
--- a/matrix_commander/matrix_commander.py
+++ b/matrix_commander/matrix_commander.py
@@ -4916,7 +4916,7 @@ async def action_devices(client: AsyncClient, credentials: dict) -> None:
                 + SEP
                 + rr.display_name
                 + SEP
-                + rr.last_seen_ip
+                + str(rr.last_seen_ip)
                 + SEP
                 + str(rr.last_seen_date)
                 + "\n"


### PR DESCRIPTION
See https://github.com/Benjamin-Loison/matrix-commander/issues/18 for details.