### PR TITLE
Dockerfile.alpine as improved Dockerfile

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,0 +1,20 @@
+FROM python:3.12-alpine3.20
+ARG NEEDED_PACKAGES_FOR_BUILD="olm-dev jpeg-dev cmake make gcc g++"
+
+RUN mkdir -p /app/matrix_commander/
+
+WORKDIR /app/
+COPY requirements.txt .
+RUN apk add --no-cache ${NEEDED_PACKAGES_FOR_BUILD} && \
+    pip3 install --no-cache -r requirements.txt && \
+    apk del --purge ${NEEDED_PACKAGES_FOR_BUILD}
+RUN apk add --no-cache libjpeg olm libmagic
+
+WORKDIR /app/matrix_commander/
+COPY matrix_commander/matrix_commander.py .
+COPY matrix_commander/matrix-commander .
+COPY matrix_commander/__init__.py .
+
+VOLUME /data
+
+ENTRYPOINT ["python3", "/app/matrix_commander/matrix-commander" ,"-s", "/data/store", "-c", "/data/credentials.json"]


### PR DESCRIPTION
It might be bit subjective but I like my Dockerfile more.

- Only ~25% of the size of the original one
- Uses official Python base image
- Python 3.12 (compromise between stability and new features)
- Alpine 3.20 (also stability / feature compromise)
- All build tools are removed after building

If you also like it better you might want to rename `Dockerfile.alpine` to `Dockerfile`