### PR TITLE
Facilitate running in docker

### DIFF
--- a/docker/matrix-commander
+++ b/docker/matrix-commander
@@ -1,0 +1,20 @@
+#!/bin/sh
+DATA_DIR="$HOME/.cache/matrix-commander"    # Directory on the host to store credentials and other data
+IMAGE="matrixcommander/matrix-commander"    # Docker image to use
+INTERACTIVE="false" # Default setting when --interactive or --pipes is not specified
+
+if [ ! -d "$DATA_DIR" ]; then
+    echo "Creating data directory at $DATA_DIR"
+    mkdir -p "$DATA_DIR"
+fi
+echo "Matrix is running in a container. Data is stored in $DATA_DIR"
+
+if [ "$1" = "--interactive" ]; then #With this setting keyboard input and screen output will be fine but piping to/from the container will not work.
+    INTERACTIVE="true"
+    shift
+elif [ "$1" = "--pipes" ]; then #With this setting keyboard input and screen output will not work but piping to/from the container will.
+    INTERACTIVE="false"
+    shift
+fi
+
+docker run -i --tty=${INTERACTIVE} --rm -v "$DATA_DIR":/data:z ${IMAGE} "$@"


### PR DESCRIPTION
This script is used to run matrix-commander in a container but without needing the docker-command and all the options.

_(Example:  Instead of `docker run --rm -v /my/chosen/folder:/data:z matrix-commander -m "hello"` the regular `matrix-commander -m "hello"` will work fine.)_

Only 1 difference: The optional options `--interactive` and `--pipes` are added to make sure piping can work probably
- If `--interactive` is given keyboard interaction will work fine (useful for things like `--login`) but piping will fail
- If `--pipes` is given keyboard interaction _might_ give problems but piping will work as expected
- If none are given the setting of the var `INTERACTIVE` in the script itself is used

